### PR TITLE
Post-London updates

### DIFF
--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -210,6 +210,22 @@ protected records. {{new-cid-content-types}} shows the record types to use:
 | heartbeat_with_cid | 28 |
 {: #new-cid-content-types}
 
+# CID authentication
+
+The CID is authenticated.  The MAC of a DTLS record with CID is generated as:
+
+~~~~
+      MAC(MAC_write_key, DTLSCompressed.epoch +
+                            DTLSCompressed.sequence_number +
+                            DTLSCompressed.type +
+                            DTLSCompressed.version +
+                            DTLSCompressed.cid +      // New input
+                            DTLSCompressed.length +
+                            DTLSCompressed.fragment);
+~~~~
+
+   where "+" denotes concatenation.
+
 # Examples
 
 {{dtls-example2}} shows an example exchange where a connection id used

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -1,6 +1,6 @@
 ---
-title: The Datagram Transport Layer Security (DTLS) 1.2 Connection Identifier
-abbrev: DTLS 1.2 Connection ID
+title: The Datagram Transport Layer Security (DTLS) Connection Identifier
+abbrev: DTLS Connection ID
 docname: draft-ietf-tls-dtls-connection-id-latest
 category: std
 updates: 6347
@@ -60,7 +60,7 @@ informative:
 --- abstract
 
 This document specifies the Connection ID construct for the Datagram Transport
-Layer Security (DTLS) protocol version 1.2.  {{I-D.ietf-tls-dtls13}} specifies
+Layer Security (DTLS) protocol.  {{I-D.ietf-tls-dtls13}} specifies
 the Connection ID for DTLS version 1.3.
 
 A Connection ID is an identifier carried in the record layer header that gives the
@@ -91,7 +91,7 @@ these values are insufficient. This is a particular issue in the Internet of Thi
 when devices enter extended sleep periods to increase their battery lifetime. The
 NAT rebinding leads to connection failure, with the resulting cost of a new handshake.
 
-This document defines an extension to DTLS 1.2 to add a connection ID to the
+This document defines an extension to DTLS to add a connection ID to the
 DTLS record layer. The presence of the connection ID is negotiated via a DTLS
 extension.
 
@@ -101,7 +101,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
 document are to be interpreted as described in RFC 2119 {{RFC2119}}.
 
-The reader is assumed to be familiar with DTLS 1.2 {{RFC6347}}.
+The reader is assumed to be familiar with DTLS {{RFC6347}}.
 
 
 # The "connection_id" Extension
@@ -157,16 +157,16 @@ for example by having the length in question be a compile-time constant.
 Note that such implementations must still be able to send other length
 connection identifiers to other parties.
 
-In DTLS 1.2, connection ids are exchanged at the beginning of the DTLS
+In DTLS, connection ids are exchanged at the beginning of the DTLS
 session only. There is no dedicated "connection id update" message
 that allows new connection ids to be established mid-session, because
-DTLS 1.2 in general does not allow TLS 1.3-style post-handshake messages
-that do not themselves begin other handshakes. DTLS 1.2 peers switch to
+DTLS in general does not allow TLS 1.3-style post-handshake messages
+that do not themselves begin other handshakes. DTLS peers switch to
 the new record layer format when encryption is enabled.
 
 # Record Layer Extensions
 
-This extension is applicable for use with DTLS 1.2 and {{dtls-record12}}
+This extension is applicable for use with DTLS and {{dtls-record12}}
 illustrates the record format.
 
 ~~~~
@@ -275,7 +275,7 @@ per-connection to on-path observers. There is no straightforward way to
 address this with connection IDs that contain arbitrary values; implementations
 concerned about this SHOULD refuse to use connection ids.
 
-An on-path adversary, who is able to observe the DTLS 1.2 protocol exchanges between the
+An on-path adversary, who is able to observe the DTLS protocol exchanges between the
 DTLS client and the DTLS server, is able to link the observed payloads to all
 subsequent payloads carrying the same connection id pair (for bi-directional
 communication).  Without multi-homing or mobility, the use of the connection id
@@ -287,7 +287,7 @@ to prevent this, implementations SHOULD attempt to use fresh connection IDs
 whenever they change local addresses or ports (though this is not always
 possible to detect).
 
-This document does not change the security properties of DTLS 1.2 {{RFC6347}}.
+This document does not change the security properties of DTLS {{RFC6347}}.
 It merely provides a more robust mechanism for associating an incoming packet
 with a stored security context.
 

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -171,18 +171,38 @@ This extension is applicable for use with DTLS 1.2 and {{dtls-record12}}
 illustrates the record format.
 
 ~~~~
-  struct {
-     ContentType type;
-     ProtocolVersion version;
-     uint16 epoch;
-     uint48 sequence_number;
-     opaque cid[cid_length];               // New field
-     uint16 length;
-     select (CipherSpec.cipher_type) {
-        case block:  GenericBlockCipher;
-        case aead:   GenericAEADCipher;
-     } fragment;
-  } DTLSCiphertext;
+   struct {
+        ContentType type;
+        ProtocolVersion version;
+        uint16 epoch;
+        uint48 sequence_number;
+        opaque cid[cid_length];               // New field
+        uint16 length;
+        opaque fragment[DTLSPlaintext.length];
+   } DTLSPlaintext;
+
+   struct {
+        ContentType type;
+        ProtocolVersion version;
+        uint16 epoch;
+        uint48 sequence_number;
+        opaque cid[cid_length];               // New field
+        uint16 length;
+        opaque fragment[DTLSCompressed.length];
+   } DTLSCompressed;
+
+   struct {
+        ContentType type;
+        ProtocolVersion version;
+        uint16 epoch;
+        uint48 sequence_number;
+        opaque cid[cid_length];               // New field
+        uint16 length;
+        select (CipherSpec.cipher_type) {
+            case block:  GenericBlockCipher;
+            case aead:   GenericAEADCipher;
+        } fragment;
+   } DTLSCiphertext;
 ~~~~
 {: #dtls-record12 title="DTLS 1.2 Record Format with Connection ID"}
 

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -177,16 +177,6 @@ illustrates the record format.
         uint48 sequence_number;
         opaque cid[cid_length];               // New field
         uint16 length;
-        opaque fragment[DTLSPlaintext.length];
-   } DTLSPlaintext;
-
-   struct {
-        ContentType type;
-        ProtocolVersion version;
-        uint16 epoch;
-        uint48 sequence_number;
-        opaque cid[cid_length];               // New field
-        uint16 length;
         opaque fragment[DTLSCompressed.length];
    } DTLSCompressed;
 

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -294,9 +294,10 @@ this document.
 IANA is requested to allocate the following new values in the "TLS ContentType
 Registry":
 
-* application_data_with_cid(25)
-* alert_with_cid(26), and
-* heartbeat_with_cid(27)
+* alert_with_cid(25)
+* handshake_with_cid(26)
+* application_data_with_cid(27)
+* heartbeat_with_cid(28)
 
 --- back
 

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -210,9 +210,10 @@ protected records. {{new-cid-content-types}} shows the record types to use:
 | heartbeat_with_cid | 28 |
 {: #new-cid-content-types}
 
-# CID authentication
 
-The CID is authenticated.  The MAC of a DTLS record with CID is generated as:
+# Record Payload Protection
+
+The CID value, when present, is included in the MAC calculation for the DTLS record. It is created as follows: 
 
 ~~~~
       MAC(MAC_write_key, DTLSCompressed.epoch +
@@ -222,9 +223,9 @@ The CID is authenticated.  The MAC of a DTLS record with CID is generated as:
                             DTLSCompressed.cid +      // New input
                             DTLSCompressed.length +
                             DTLSCompressed.fragment);
+   where "+" denotes concatenation.
 ~~~~
 
-   where "+" denotes concatenation.
 
 # Examples
 

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -63,13 +63,12 @@ This document specifies the Connection ID construct for the Datagram Transport
 Layer Security (DTLS) protocol version 1.2.  {{I-D.ietf-tls-dtls13}} specifies
 the Connection ID for DTLS version 1.3.
 
-A Connection ID is an identifier carried in the record layer header that gives
-the recipient additional information for selecting the appropriate security
-association.  In "classical" DTLS, selecting a security association of an
-incoming DTLS record is accomplished with the help of the 5-tuple.  If the
-source IP address and/or source port changes during the lifetime of a DTLS
-session then the receiver will be unable to locate the correct security
-context.
+A Connection ID is an identifier carried in the record layer header that gives the
+recipient additional information for selecting the appropriate security association.
+In "classical" DTLS, selecting a security association of an incoming DTLS record
+is accomplished with the help of the 5-tuple. If the source IP address and/or
+source port changes during the lifetime of an ongoing DTLS session then the
+receiver will be unable to locate the correct security context.
 
 --- middle
 
@@ -132,7 +131,7 @@ the server to use a zero-length CID; the result is the same).
   } ConnectionId;
 ~~~~
 
-A server that is willing to use CIDs will respond with its own
+A server which is willing to use CIDs will respond with its own
 "connection_id" extension, containing the CID it wishes the
 client to use when sending messages towards it. A zero-length value
 indicates that the server will send with the client's CID but does not
@@ -209,11 +208,17 @@ illustrates the record format.
 Note that for both record formats, it is not possible to parse the
 records without knowing how long the Connection ID is.
 
-In order to help the receiver discerning a record bearing a Connection ID from
-one that doesn't, the ContentType of the record containing the cid field MUST
-be: application_data_with_cid(25) instead of application_data(23),
-alert_with_cid(26) instead of alert(24) and heartbeat_with_cid(27) instead of
-heartbeat(24).
+In order to allow a receiver to determine whether a record has CID or not,
+connections which have negotiated this extension use new record types for all
+protected records. {{new-cid-content-types}} shows the record types to use:
+
+| New ContentType | Value |
+|--------------|-----------|
+| alert_with_cid | 25 |
+| handshake_with_cid | 26 |
+| application_data_with_cid | 27 |
+| heartbeat_with_cid | 28 |
+{: #new-cid-content-types}
 
 # Examples
 

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -3,7 +3,7 @@ title: The Datagram Transport Layer Security (DTLS) 1.2 Connection Identifier
 abbrev: DTLS 1.2 Connection ID
 docname: draft-ietf-tls-dtls-connection-id-latest
 category: std
-obsoletes: 6347
+updates: 6347
 
 ipr: pre5378Trust200902
 area: Security


### PR DESCRIPTION
- Remove 1.3 references (based on Hannes's PR #2);
- Protect CID;
- Initial sketch for explicit marking of CID records using ad hoc CTs.