### PR TITLE
Remove exposition

### DIFF
--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -140,6 +140,9 @@ indicates that the server will send with the client's CID but does not
 wish the client to use a CID (or again, alternately, to use a
 zero-length CID).
 
+Having endpoints select the CID that is used by peers gives implementations
+flexibility in the choice of how to format and generate CIDs.
+
 When a session is resumed, the "connection_id" extension is
 negotiated afresh, not retained from previous connections in
 the session.

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -144,13 +144,6 @@ When a session is resumed, the "connection_id" extension is
 negotiated afresh, not retained from previous connections in
 the session.
 
-This is effectively the simplest possible design that will work.
-Previous design ideas for using cryptographically generated session
-ids, either using hash chains or public key encryption, were dismissed
-due to their inefficient designs. Note that a client always has the
-chance to fall back to a full handshake or more precisely to a
-handshake that uses session resumption.
-
 Because each party sends in the extension_data the value that it will
 receive as a connection identifier in encrypted records, it is possible
 for an endpoint to use a globally constant length for such connection


### PR DESCRIPTION
> This is effectively the simplest possible design that will work.

Not that important to say.

> Previous design ideas for using cryptographically generated session ids, either using hash chains or public key encryption, were dismissed due to their inefficient designs. 

Same.

> Note that a client always has the chance to fall back to a full handshake or more precisely to a handshake that uses session resumption.

Why this is a relevant statement is baffling.  The point that is being made is that more complex designs might allow a connection to continue in the face of path changes (and NAT rebindings), but these are far too complex and in cases where a connection ID is insufficient, a new connection is probably easier to manage.

But you don't need to say all of that.