### PR TITLE
Disallow sending MAC failure fatal alerts to non-validated peers

### DIFF
--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -366,7 +366,10 @@ in changing a peer address if they are able to rewrite source addresses
 and if replayed packets are able to arrive before any original. 
 
 - There is a strategy for ensuring that the new peer address is able to 
-receive and process DTLS records. No such test is defined in this	specification. 
+receive and process DTLS records. No such test is defined in this specification.
+
+If any of the above checks fails, the receiver MUST silently discard the
+record.
 
 The above is necessary to protect against attacks that use datagrams with 
 spoofed addresses or replayed datagrams to trigger attacks. Note that there 

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -352,7 +352,7 @@ different than the one currently associated with the DTLS connection,
 the receiver MUST NOT 
 * replace the address it uses for sending records to its peer with the 
   source address specified in the received datagram, or
-* send a response of any kind to the record, including sending FatalAlerts
+* send a response of any kind to the record, including sending alerts
   in response to an invalid record,
 unless the following conditions are met:
 

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -371,10 +371,7 @@ and if replayed packets are able to arrive before any original.
 - There is a strategy for ensuring that the new peer address is able to 
 receive and process DTLS records. No such test is defined in this specification.
 
-If any of the above conditions fail, the receiver MUST silently discard the
-received datagram.
-
-The above is necessary to protect against attacks that use datagrams with 
+The conditions above are necessary to protect against attacks that use datagrams with 
 spoofed addresses or replayed datagrams to trigger attacks. Note that there 
 is no requirement to use of the anti-replay window mechanism defined in 
 Section 4.1.2.6 of DTLS 1.2. Both solutions, the "anti-replay window" or 

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -349,12 +349,9 @@ data the following modification is made to the additional data calculation.
 
 When a record with a CID is received that has a source address 
 different than the one currently associated with the DTLS connection,
-the receiver MUST NOT 
-* replace the address it uses for sending records to its peer with the 
-  source address specified in the received datagram, or
-* send a response of any kind to the record, including sending alerts
-  in response to an invalid record,
-unless the following conditions are met:
+the receiver MUST NOT replace the address it uses for sending records 
+to its peer with the source address specified in the received datagram
+unless the following three conditions are met:
 
 - The received datagram has been cryptographically verified using 
 the DTLS record layer processing procedures.
@@ -387,6 +384,9 @@ successful exchange of minimal amount of ping-pong traffic with the peer.
 Alternatively, an DTLS-specific mechanism may be used, as described in 
 {{!I-D.tschofenig-tls-dtls-rrc}}.
 
+DTLS implementations MUST silently discard records with bad MACs or that are 
+otherwise invalid.
+  
 # Examples
 
 {{dtls-example2}} shows an example exchange where a CID is

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -348,10 +348,13 @@ data the following modification is made to the additional data calculation.
 # Peer Address Update {#peer-address-update}
 
 When a record with a CID is received that has a source address 
-different than the one currently associated with the DTLS connection, 
-the receiver MUST NOT replace the address it uses for sending records 
-to its peer with the source address specified in the received 
-datagram unless the following conditions are met: 
+different than the one currently associated with the DTLS connection,
+the receiver MUST NOT 
+* replace the address it uses for sending records to its peer with the 
+  source address specified in the received datagram, or
+* send a response of any kind to the record, including sending FatalAlerts
+  in response to an invalid record,
+unless the following conditions are met:
 
 - The received datagram has been cryptographically verified using 
 the DTLS record layer processing procedures.

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -371,8 +371,8 @@ and if replayed packets are able to arrive before any original.
 - There is a strategy for ensuring that the new peer address is able to 
 receive and process DTLS records. No such test is defined in this specification.
 
-If any of the above checks fails, the receiver MUST silently discard the
-record.
+If any of the above conditions fail, the receiver MUST silently discard the
+received datagram.
 
 The above is necessary to protect against attacks that use datagrams with 
 spoofed addresses or replayed datagrams to trigger attacks. Note that there 


### PR DESCRIPTION
Fixes #72 