### PR TITLE
clarify "replace the address"

### DIFF
--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -380,7 +380,6 @@ data the following modification is made to the additional data calculation.
 When a record with a CID is received that has a source address
 different from the one currently associated with the DTLS connection,
 the receiver MUST NOT replace the address it uses for sending records
-(other than specific probing packets)
 to its peer with the source address specified in the received datagram,
 unless the following three conditions are met:
 

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -397,7 +397,8 @@ and if replayed packets are able to arrive before any original.
 
 - There is a strategy for ensuring that the new peer address is able to
 receive and process DTLS records. No strategy is mandated by this specification 
-but see note (*) below. 
+but see note (*) below. (Such a strategy might include sending specific
+probing packets to the new peer address.)
 
 The conditions above are necessary to protect against attacks that use datagrams with
 spoofed addresses or replayed datagrams to trigger attacks. Note that there

--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -380,6 +380,7 @@ data the following modification is made to the additional data calculation.
 When a record with a CID is received that has a source address
 different from the one currently associated with the DTLS connection,
 the receiver MUST NOT replace the address it uses for sending records
+(other than specific probing packets)
 to its peer with the source address specified in the received datagram,
 unless the following three conditions are met:
 


### PR DESCRIPTION
[just something I was thinking about in looking at John's ballot comment.  I'm not 100% sure whether this is actually needed or helpful.]

This refers to the default address to send stuff to, but should not
exclude one-offs that go elsewhere as deliberate probes.