### PR TITLE
"DTLS was designed for securing connection-less transports, like UDP"

### DIFF
--- a/draft-ietf-tls-dtls-connection-id.md
+++ b/draft-ietf-tls-dtls-connection-id.md
@@ -78,7 +78,7 @@ and record-layer padding.
 #  Introduction
 
 The Datagram Transport Layer Security (DTLS) {{RFC6347}} protocol was designed for
-securing connection-less transports, like UDP. DTLS, like TLS, starts
+securing application data sent over datagram protocols, like UDP. DTLS, like TLS, starts
 with a handshake, which can be computationally demanding (particularly
 when public key cryptography is used). After a successful handshake,
 symmetric key cryptography is used to apply data origin


### PR DESCRIPTION
"(DTLS) {{RFC6347}} protocol was designed for securing connection-less transports, like UDP"

- I am not sure that "connection-less" is true. DTLS 1.0 (RFC4347) only mentions datagram protocols
and it was quickly used to protect data over connection-oriented datagram protocols like SCTP.
RFC6083bis (DTLS over SCTP) will likely rely heavily on DTLS Connection ID (at least that is
the current plan).

- Also DTLS in not really securing UDP, it secures the data sent over UDP.